### PR TITLE
Make open yRangeValues and defaultLineColor from LineChartRendererSegmented

### DIFF
--- a/Source/Charts/Renderers/LineChartRendererSegmented.swift
+++ b/Source/Charts/Renderers/LineChartRendererSegmented.swift
@@ -20,8 +20,8 @@ open class LineChartRendererSegmented: LineChartRenderer
     // Calculated based on the color array for the dataset
     // If y Axis has n range (n+1) lables provide n values in color array. Default color will be `defaultLineColor`
     private var rangeColor: [ClosedRange<Double>: UIColor] = [:]
-    var yRangeValues = [Double]()
-    var defaultLineColor: UIColor = .black
+    open var yRangeValues = [Double]()
+    open var defaultLineColor: UIColor = .black
     
     @objc open override func drawLinear(context: CGContext, dataSet: LineChartDataSetProtocol)
     {


### PR DESCRIPTION

### Issue Link :link:
Make yRangeValues and defaultLineColor accessible from outside

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->